### PR TITLE
container fix

### DIFF
--- a/src/main/java/lycanitestweaks/handlers/ForgeConfigHandler.java
+++ b/src/main/java/lycanitestweaks/handlers/ForgeConfigHandler.java
@@ -938,6 +938,19 @@ public class ForgeConfigHandler {
 		@Config.RequiresMcRestart
 		@MixinConfig.LateMixin(name = "mixins.lycanitestweaks.patcheserpixblizzardoffset.json")
 		public boolean fixSerpixBlizzardOffset = true;
+
+		@Config.Comment("All Lyc containers (Equipment Forges, Infuser, Station, Summoning Pedestal) have no Item Quick Move implementation (via shift clicking). This fix makes them use newer mc quick move mechanics where the crafting slots are preferred over the player inventory+hotbar.\n" +
+				"Also fixes a minimal bug in Lyca Pet chest inventory where one slot (bottom right in player inventory) was not reachable via quick move.")
+		@Config.Name("Fix Container Quick Move")
+		@Config.RequiresMcRestart
+		@MixinConfig.LateMixin(name = "mixins.lycanitestweaks.containerbettershifting.json")
+		public boolean fixContainerQuickMove = true;
+
+		@Config.Comment("Players can only interact with Lyca crafting blocks from very low distances. This fix instead makes them copy the vanilla block (crafting table, furnace etc) behavior")
+		@Config.Name("Fix Tile Entity Interaction Distance")
+		@Config.RequiresMcRestart
+		@MixinConfig.LateMixin(name = "mixins.lycanitestweaks.tileentityinteractiondistance.json")
+		public boolean fixTileEntityInteractionDistance = true;
 	}
 
 	public static HashSet<ResourceLocation> getCleansedCureEffects(){

--- a/src/main/java/lycanitestweaks/mixin/lycanitesmobspatches/core/containers/BaseContainerMixin.java
+++ b/src/main/java/lycanitestweaks/mixin/lycanitesmobspatches/core/containers/BaseContainerMixin.java
@@ -1,0 +1,19 @@
+package lycanitestweaks.mixin.lycanitesmobspatches.core.containers;
+
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import com.lycanitesmobs.core.container.BaseContainer;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+@Mixin(BaseContainer.class)
+public abstract class BaseContainerMixin {
+
+    @ModifyExpressionValue(
+            method = "transferStackInSlot",
+            at = @At(value = "FIELD", target = "Lcom/lycanitesmobs/core/container/BaseContainer;playerInventoryFinish:I", ordinal = 1, remap = false)
+    )
+    public int rlmixins_baseContainer_transferStackInSlot(int original) {
+        //Moving back to player inventory ignored last slot (bottom right in inventory, not hotbar) bc of an off-by-one
+        return original + 1;
+    }
+}

--- a/src/main/java/lycanitestweaks/mixin/lycanitesmobspatches/core/containers/EquipmentForgeContainerMixin.java
+++ b/src/main/java/lycanitestweaks/mixin/lycanitesmobspatches/core/containers/EquipmentForgeContainerMixin.java
@@ -1,0 +1,86 @@
+package lycanitestweaks.mixin.lycanitesmobspatches.core.containers;
+
+import com.lycanitesmobs.core.container.EquipmentForgeContainer;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.inventory.Container;
+import net.minecraft.inventory.Slot;
+import net.minecraft.item.ItemStack;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
+
+import javax.annotation.Nonnull;
+
+@Mixin(EquipmentForgeContainer.class)
+public abstract class EquipmentForgeContainerMixin extends Container {
+
+    /**
+     * @author Nischhelm
+     * @reason base lyca removed the whole quick move mechanic from all the containers except pet inventory, this reinstates it
+     */
+    @Overwrite
+    @Nonnull
+    public ItemStack transferStackInSlot(EntityPlayer player, int index) {
+        ItemStack stackOriginalInSlot = ItemStack.EMPTY;
+        Slot slot = this.inventorySlots.get(index);
+
+        if (slot != null && slot.getHasStack()) {
+            ItemStack stackRemainingInSlot = slot.getStack();
+            stackOriginalInSlot = stackRemainingInSlot.copy();
+
+            /*
+            0 to 8 player hotbar
+            9 to 35 player inv
+            36 tool
+            37 base
+            38 head
+            39 tipA
+            40 tipB
+            41 tipC
+            42 pommel
+             */
+
+            //Move from tool slot to hotbar/inventory
+            if(index == 36){
+                if (!this.mergeItemStack(stackRemainingInSlot, 0, 9, true) &&
+                        !this.mergeItemStack(stackRemainingInSlot, 9, 36, true))
+                    return ItemStack.EMPTY;
+
+                slot.onSlotChange(stackRemainingInSlot, stackOriginalInSlot);
+            }
+            //Move from tool part slot to hotbar/inventory
+            else if (index >= 37) {
+                //Hotbar and Inventory are swapped in Lyca Containers, so we have to split it up, technically this is stupid af
+                if (
+                    !this.mergeItemStack(stackRemainingInSlot, 9, 36, false) &&
+                    !this.mergeItemStack(stackRemainingInSlot, 0, 9, false)
+                )
+                    return ItemStack.EMPTY;
+
+                slot.onSlotChange(stackRemainingInSlot, stackOriginalInSlot);
+            }
+            //Move from hotbar+inventory to charge/tool slots
+            else if (!this.mergeItemStack(stackRemainingInSlot, 36, 43, false)) {
+                return ItemStack.EMPTY;
+            }
+            //Move from inventory to hotbar
+            else if (index >= 9 && index < 35) {
+                if (!this.mergeItemStack(stackRemainingInSlot, 0, 9, false))
+                    return ItemStack.EMPTY;
+            }
+            //Move from hotbar to inventory
+            else if (index >= 0 && index < 9) {
+                if (!this.mergeItemStack(stackRemainingInSlot, 9, 36, false))
+                    return ItemStack.EMPTY;
+            }
+
+            if (stackRemainingInSlot.isEmpty()) slot.putStack(ItemStack.EMPTY);
+            else slot.onSlotChanged();
+
+            if (stackRemainingInSlot.getCount() == stackOriginalInSlot.getCount()) return ItemStack.EMPTY;
+
+            slot.onTake(player, stackRemainingInSlot);
+        }
+
+        return stackOriginalInSlot;
+    }
+}

--- a/src/main/java/lycanitestweaks/mixin/lycanitesmobspatches/core/containers/EquipmentInfuserContainerMixin.java
+++ b/src/main/java/lycanitestweaks/mixin/lycanitesmobspatches/core/containers/EquipmentInfuserContainerMixin.java
@@ -1,0 +1,71 @@
+package lycanitestweaks.mixin.lycanitesmobspatches.core.containers;
+
+import com.lycanitesmobs.core.container.EquipmentInfuserContainer;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.inventory.Container;
+import net.minecraft.inventory.Slot;
+import net.minecraft.item.ItemStack;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
+
+import javax.annotation.Nonnull;
+
+@Mixin(EquipmentInfuserContainer.class)
+public abstract class EquipmentInfuserContainerMixin extends Container {
+
+    /**
+     * @author Nischhelm
+     * @reason base lyca removed the whole quick move mechanic from all the containers except pet inventory, this reinstates it
+     */
+    @Overwrite
+    @Nonnull
+    public ItemStack transferStackInSlot(EntityPlayer player, int index) {
+        ItemStack stackOriginalInSlot = ItemStack.EMPTY;
+        Slot slot = this.inventorySlots.get(index);
+
+        if (slot != null && slot.getHasStack()) {
+            ItemStack stackRemainingInSlot = slot.getStack();
+            stackOriginalInSlot = stackRemainingInSlot.copy();
+
+            /*
+            0 to 8 player hotbar
+            9 to 35 player inv
+            36 charge
+            37 tool
+             */
+
+            //Move from charge/tool slots to hotbar/inventory
+            if (index == 36 || index == 37) {
+                //Hotbar and Inventory are swapped in Lyca Containers, so we have to split it up, technically this is stupid af
+                if (!this.mergeItemStack(stackRemainingInSlot, 0, 9, true) &&
+                        !this.mergeItemStack(stackRemainingInSlot, 9, 36, true))
+                    return ItemStack.EMPTY;
+
+                slot.onSlotChange(stackRemainingInSlot, stackOriginalInSlot);
+            }
+            //Move from hotbar+inventory to charge/tool slots
+            else if (!this.mergeItemStack(stackRemainingInSlot, 36, 38, false))
+                return ItemStack.EMPTY;
+
+            //Move from inventory to hotbar
+            else if (index >= 9 && index < 35) {
+                if (!this.mergeItemStack(stackRemainingInSlot, 0, 9, false))
+                    return ItemStack.EMPTY;
+            }
+            //Move from hotbar to inventory
+            else if (index >= 0 && index < 9) {
+                if (!this.mergeItemStack(stackRemainingInSlot, 9, 36, false))
+                    return ItemStack.EMPTY;
+            }
+
+            if (stackRemainingInSlot.isEmpty()) slot.putStack(ItemStack.EMPTY);
+            else slot.onSlotChanged();
+
+            if (stackRemainingInSlot.getCount() == stackOriginalInSlot.getCount()) return ItemStack.EMPTY;
+
+            slot.onTake(player, stackRemainingInSlot);
+        }
+
+        return stackOriginalInSlot;
+    }
+}

--- a/src/main/java/lycanitestweaks/mixin/lycanitesmobspatches/core/containers/EquipmentStationContainerMixin.java
+++ b/src/main/java/lycanitestweaks/mixin/lycanitesmobspatches/core/containers/EquipmentStationContainerMixin.java
@@ -1,0 +1,71 @@
+package lycanitestweaks.mixin.lycanitesmobspatches.core.containers;
+
+import com.lycanitesmobs.core.container.EquipmentStationContainer;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.inventory.Container;
+import net.minecraft.inventory.Slot;
+import net.minecraft.item.ItemStack;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
+
+import javax.annotation.Nonnull;
+
+@Mixin(EquipmentStationContainer.class)
+public abstract class EquipmentStationContainerMixin extends Container {
+
+    /**
+     * @author Nischhelm
+     * @reason base lyca removed the whole quick move mechanic from all the containers except pet inventory, this reinstates it
+     */
+    @Overwrite
+    @Nonnull
+    public ItemStack transferStackInSlot(EntityPlayer player, int index) {
+        ItemStack stackOriginalInSlot = ItemStack.EMPTY;
+        Slot slot = this.inventorySlots.get(index);
+
+        if (slot != null && slot.getHasStack()) {
+            ItemStack stackRemainingInSlot = slot.getStack();
+            stackOriginalInSlot = stackRemainingInSlot.copy();
+
+            /*
+            0 to 8 player hotbar
+            9 to 35 player inv
+            36 repair material
+            37 tool
+             */
+
+            //Move from charge/tool slots to hotbar/inventory
+            if (index >= 36) {
+                //Hotbar and Inventory are swapped in Lyca Containers, so we have to split it up, technically this is stupid af
+                if (!this.mergeItemStack(stackRemainingInSlot, 0, 9, true) &&
+                        !this.mergeItemStack(stackRemainingInSlot, 9, 36, true))
+                    return ItemStack.EMPTY;
+
+                slot.onSlotChange(stackRemainingInSlot, stackOriginalInSlot);
+            }
+            //Move from hotbar+inventory to charge/tool slots
+            else if (!this.mergeItemStack(stackRemainingInSlot, 36, 38, false))
+                return ItemStack.EMPTY;
+
+            //Move from inventory to hotbar
+            else if (index >= 9 && index < 35) {
+                if (!this.mergeItemStack(stackRemainingInSlot, 0, 9, false))
+                    return ItemStack.EMPTY;
+            }
+            //Move from hotbar to inventory
+            else if (index >= 0 && index < 9) {
+                if (!this.mergeItemStack(stackRemainingInSlot, 9, 36, false))
+                    return ItemStack.EMPTY;
+            }
+
+            if (stackRemainingInSlot.isEmpty()) slot.putStack(ItemStack.EMPTY);
+            else slot.onSlotChanged();
+
+            if (stackRemainingInSlot.getCount() == stackOriginalInSlot.getCount()) return ItemStack.EMPTY;
+
+            slot.onTake(player, stackRemainingInSlot);
+        }
+
+        return stackOriginalInSlot;
+    }
+}

--- a/src/main/java/lycanitestweaks/mixin/lycanitesmobspatches/core/containers/SummoningPedestalContainerMixin.java
+++ b/src/main/java/lycanitestweaks/mixin/lycanitesmobspatches/core/containers/SummoningPedestalContainerMixin.java
@@ -1,0 +1,55 @@
+package lycanitestweaks.mixin.lycanitesmobspatches.core.containers;
+
+import com.lycanitesmobs.core.container.SummoningPedestalContainer;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.inventory.Container;
+import net.minecraft.inventory.Slot;
+import net.minecraft.item.ItemStack;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
+
+import javax.annotation.Nonnull;
+
+@Mixin(SummoningPedestalContainer.class)
+public abstract class SummoningPedestalContainerMixin extends Container {
+
+    /**
+     * @author Nischhelm
+     * @reason base lyca removed the whole quick move mechanic from all the containers except pet inventory, this reinstates it
+     */
+    @Overwrite
+    @Nonnull
+    public ItemStack transferStackInSlot(EntityPlayer player, int index) {
+        ItemStack stackOriginalInSlot = ItemStack.EMPTY;
+        Slot slot = this.inventorySlots.get(index);
+
+        if (slot != null && slot.getHasStack()) {
+            ItemStack stackRemainingInSlot = slot.getStack();
+            stackOriginalInSlot = stackRemainingInSlot.copy();
+
+            /*
+            0 to 8 player hotbar
+            9 material
+             */
+
+            //Move from material slot to hotbar
+            if (index == 9) {
+                //Hotbar and Inventory are swapped in Lyca Containers, so we have to split it up, technically this is stupid af
+                if (!this.mergeItemStack(stackRemainingInSlot, 0, 9, true))
+                    return ItemStack.EMPTY;
+            }
+            //Move from hotbar to material slot
+            else if (!this.mergeItemStack(stackRemainingInSlot, 9, 10, false))
+                return ItemStack.EMPTY;
+
+            if (stackRemainingInSlot.isEmpty()) slot.putStack(ItemStack.EMPTY);
+            else slot.onSlotChanged();
+
+            if (stackRemainingInSlot.getCount() == stackOriginalInSlot.getCount()) return ItemStack.EMPTY;
+
+            slot.onTake(player, stackRemainingInSlot);
+        }
+
+        return stackOriginalInSlot;
+    }
+}

--- a/src/main/java/lycanitestweaks/mixin/lycanitesmobspatches/core/containers/TileEntityBaseMixin.java
+++ b/src/main/java/lycanitestweaks/mixin/lycanitesmobspatches/core/containers/TileEntityBaseMixin.java
@@ -1,0 +1,29 @@
+package lycanitestweaks.mixin.lycanitesmobspatches.core.containers;
+
+import com.lycanitesmobs.core.tileentity.TileEntityBase;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.inventory.ISidedInventory;
+import net.minecraft.tileentity.TileEntity;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+
+import javax.annotation.Nonnull;
+
+@Mixin(TileEntityBase.class)
+public abstract class TileEntityBaseMixin extends TileEntity implements ISidedInventory {
+    @Shadow(remap = false) protected boolean destroyed;
+
+    /**
+     * @author Nischhelm
+     * Lyca has max distance of 4 blocks which i guess is from way older versions. In any way, it feels weird not being able to interact with the blocks from medium distances.
+     * This uses the default behavior that vanilla tile entities use.
+     * Using Override instead of Overwrite cause remapping is weird here. Works just the same though.
+     */
+    @Override
+    public boolean isUsableByPlayer(@Nonnull EntityPlayer player) {
+        if (this.destroyed || this.world.getTileEntity(this.pos) != this)
+            return false;
+        else
+            return player.getDistanceSq((double)this.pos.getX() + 0.5D, (double)this.pos.getY() + 0.5D, (double)this.pos.getZ() + 0.5D) <= 64.0D;
+    }
+}

--- a/src/main/resources/mixins.lycanitestweaks.containerbettershifting.json
+++ b/src/main/resources/mixins.lycanitestweaks.containerbettershifting.json
@@ -1,0 +1,18 @@
+{
+  "required": true,
+  "package": "lycanitestweaks.mixin.lycanitesmobspatches.core.containers",
+  "refmap": "mixins.rlmixins.refmap.json",
+  "compatibilityLevel": "JAVA_8",
+  "target": "@env(DEFAULT)",
+  "minVersion": "0.8",
+  "mixins": [
+    "EquipmentInfuserContainerMixin",
+    "EquipmentForgeContainerMixin",
+    "EquipmentStationContainerMixin",
+    "BaseContainerMixin",
+    "SummoningPedestalContainerMixin"
+  ],
+  "injectors": {
+    "maxShiftBy": 10
+  }
+}

--- a/src/main/resources/mixins.lycanitestweaks.tileentityinteractiondistance.json
+++ b/src/main/resources/mixins.lycanitestweaks.tileentityinteractiondistance.json
@@ -1,0 +1,14 @@
+{
+  "required": true,
+  "package": "lycanitestweaks.mixin.lycanitesmobspatches.core.containers",
+  "refmap": "mixins.rlmixins.refmap.json",
+  "compatibilityLevel": "JAVA_8",
+  "target": "@env(DEFAULT)",
+  "minVersion": "0.8",
+  "mixins": [
+    "TileEntityBaseMixin"
+  ],
+  "injectors": {
+    "maxShiftBy": 10
+  }
+}


### PR DESCRIPTION
- added item quick move (shift clicking) handling for lyca containers
- fixed lyca pet container quick move ignoring one player inventory slot
- fixed lyca tile entity interaction distance